### PR TITLE
chore(hotfix): disable babel run-time transformation in frontend code

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -29,8 +29,8 @@ gulp.task('lint', () => (
     'test/**/*.js'
   ])
     .pipe(eslint())
-    // .pipe(eslint.format())
-    // .pipe(eslint.failAfterError())
+    .pipe(eslint.format())
+    .pipe(eslint.failAfterError())
 ));
 
 gulp.task('transpile-app', ['lint'], () => (
@@ -85,9 +85,6 @@ gulp.task('public:js', ['lint'], () => (
   gulp.src('public/js/**/*.js')
     .pipe(newer('dist/public/js'))
     .pipe(sourcemaps.init())
-    .pipe(babel({
-      plugins: ['transform-runtime']
-    }))
     .pipe(sourcemaps.write('.'))
     .pipe(gulp.dest('dist/public/js'))
 ));


### PR DESCRIPTION
#### What does this PR do?
Fixes app crash due to require statements in transpiled version of app browser code

#### Description of Task to be completed?
Remove babel-runtime transform from gulp task for transpiling frontend code

#### How should this be manually tested?
`npm run start:dev`

#### Any background context you want to provide?
None

#### What are the relevant pivotal tracker stories?
None
